### PR TITLE
Enable multi-connection connection management UX

### DIFF
--- a/components/Canvas.tsx
+++ b/components/Canvas.tsx
@@ -43,9 +43,10 @@ interface CanvasProps {
   onGenerateScreenplay: (nodeId: string) => void;
   onOpenTextModal: (title: string, text: string) => void;
   onImageClick: (imageUrl: string) => void;
-  onOutputMouseDown: (nodeId: string, handleId: string) => void;
-  onInputMouseDown: (nodeId: string, handleId: string) => void;
+  onOutputMouseDown: (nodeId: string, handleId: string, event?: React.MouseEvent) => void;
+  onInputMouseDown: (nodeId: string, handleId: string, event?: React.MouseEvent) => void;
   onInputMouseUp: (nodeId: string, handleId: string) => void;
+  onRemoveConnection: (connectionId: string) => void;
   onDeleteNode: (nodeId: string) => void;
   onDeleteNodeDirectly: (nodeId: string) => void;
   onDuplicateNode: (nodeId: string) => string | null;
@@ -104,6 +105,7 @@ const Canvas = forwardRef<HTMLDivElement, CanvasProps>(({
   mousePosition,
   hoveredInputHandle,
   setHoveredInputHandle,
+  onRemoveConnection,
 }, ref) => {
   const { styles } = useTheme();
   const baseGridSize = 24;
@@ -193,6 +195,7 @@ const Canvas = forwardRef<HTMLDivElement, CanvasProps>(({
             onOutputMouseDown={onOutputMouseDown}
             onInputMouseDown={onInputMouseDown}
             onInputMouseUp={onInputMouseUp}
+            onRemoveConnection={onRemoveConnection}
             onDelete={onDeleteNode}
             onDeleteDirectly={onDeleteNodeDirectly}
             onDuplicate={onDuplicateNode}


### PR DESCRIPTION
## Summary
- stop clearing existing cables when starting a new drag so outputs can fan out, while keeping an Alt/Option shortcut to disconnect all
- reuse a shared `removeConnection` helper and update Image Mixer inputs so individual inbound links can be released instead of wiping the whole handle
- surface inline connection chips on each populated handle that list linked nodes and expose one-click removal actions

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68dd68418174832ebde3c16a1ead56aa