### PR TITLE
Allow multi-input image mixer and multi-output handles

### DIFF
--- a/components/Canvas.tsx
+++ b/components/Canvas.tsx
@@ -224,9 +224,13 @@ const Canvas = forwardRef<HTMLDivElement, CanvasProps>(({
                   const fromPos = getNodeHandlePosition(fromNode, conn.fromHandleId, 'output');
                   const toPos = getNodeHandlePosition(toNode, conn.toHandleId, 'input');
                   
+                  const toHandleSpec = getHandleSpec(toNode, conn.toHandleId, 'input');
+                  const allowsMultipleConnections = toHandleSpec?.allowMultipleConnections ?? false;
+
                   const isPendingReplacement = tempConnectionInfo !== null &&
                     conn.toNodeId === hoveredInputHandle?.nodeId &&
-                    conn.toHandleId === hoveredInputHandle?.handleId;
+                    conn.toHandleId === hoveredInputHandle?.handleId &&
+                    !allowsMultipleConnections;
 
                   const fromHandleSpec = getHandleSpec(fromNode, conn.fromHandleId, 'output');
                   if (!fromHandleSpec) return null;

--- a/utils/node-spec.ts
+++ b/utils/node-spec.ts
@@ -4,6 +4,7 @@ export interface NodeHandleSpec {
   id: string;
   type: HandleType;
   label: string;
+  allowMultipleConnections?: boolean;
 }
 
 export interface NodeSpec {
@@ -14,11 +15,11 @@ export interface NodeSpec {
 export const NODE_SPEC: { [key in NodeType]: NodeSpec } = {
   [NodeType.Text]: {
     inputs: [],
-    outputs: [{ id: 'text_output', type: HandleType.Text, label: 'Text' }],
+    outputs: [{ id: 'text_output', type: HandleType.Text, label: 'Text', allowMultipleConnections: true }],
   },
   [NodeType.Image]: {
     inputs: [],
-    outputs: [{ id: 'image_output', type: HandleType.Image, label: 'Image' }],
+    outputs: [{ id: 'image_output', type: HandleType.Image, label: 'Image', allowMultipleConnections: true }],
   },
   [NodeType.TextGenerator]: {
     inputs: [{ id: 'prompt_input', type: HandleType.Text, label: 'Prompt' }],
@@ -42,7 +43,7 @@ export const NODE_SPEC: { [key in NodeType]: NodeSpec } = {
     outputs: [{ id: 'image_output', type: HandleType.Image, label: 'Output Image' }],
   },
   [NodeType.ImageMixer]: {
-    inputs: [{ id: 'image_input', type: HandleType.Image, label: 'Images' }],
+    inputs: [{ id: 'image_input', type: HandleType.Image, label: 'Images', allowMultipleConnections: true }],
     outputs: [{ id: 'image_output', type: HandleType.Image, label: 'Mixed Image' }],
   },
   [NodeType.StoryCharacterCreator]: {


### PR DESCRIPTION
## Summary
- add an `allowMultipleConnections` flag to handle specs and enable it for text/image outputs and the mixer image input
- update connection handling to respect the multi-connection flag, preventing unintended replacements and duplicates
- adjust canvas connector highlighting so multi-input handles are not shown as pending replacement

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd73f276fc832ea837a96f0a5fcafb