### PR TITLE
Add world bible, beat planning, and video sequencing nodes

### DIFF
--- a/components/Canvas.tsx
+++ b/components/Canvas.tsx
@@ -41,6 +41,12 @@ interface CanvasProps {
   onExpandStory: (nodeId: string) => void;
   onGenerateShortStory: (nodeId: string) => void;
   onGenerateScreenplay: (nodeId: string) => void;
+  onGenerateWorldBible: (nodeId: string) => void;
+  onGenerateSceneBeats: (nodeId: string) => void;
+  onGenerateShotPrompts: (nodeId: string) => void;
+  onGenerateVideoKeyframe: (nodeId: string) => void;
+  onSyncVideoSequence: (nodeId: string) => void;
+  onExportVideoSequence: (nodeId: string) => void;
   onOpenTextModal: (title: string, text: string) => void;
   onImageClick: (imageUrl: string) => void;
   onOutputMouseDown: (nodeId: string, handleId: string) => void;
@@ -86,6 +92,12 @@ const Canvas = forwardRef<HTMLDivElement, CanvasProps>(({
   onExpandStory,
   onGenerateShortStory,
   onGenerateScreenplay,
+  onGenerateWorldBible,
+  onGenerateSceneBeats,
+  onGenerateShotPrompts,
+  onGenerateVideoKeyframe,
+  onSyncVideoSequence,
+  onExportVideoSequence,
   onOpenTextModal,
   onImageClick,
   onOutputMouseDown,
@@ -188,6 +200,12 @@ const Canvas = forwardRef<HTMLDivElement, CanvasProps>(({
             onExpandStory={onExpandStory}
             onGenerateShortStory={onGenerateShortStory}
             onGenerateScreenplay={onGenerateScreenplay}
+            onGenerateWorldBible={onGenerateWorldBible}
+            onGenerateSceneBeats={onGenerateSceneBeats}
+            onGenerateShotPrompts={onGenerateShotPrompts}
+            onGenerateVideoKeyframe={onGenerateVideoKeyframe}
+            onSyncVideoSequence={onSyncVideoSequence}
+            onExportVideoSequence={onExportVideoSequence}
             onOpenTextModal={onOpenTextModal}
             onImageClick={onImageClick}
             onOutputMouseDown={onOutputMouseDown}

--- a/components/Node.tsx
+++ b/components/Node.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useState, useLayoutEffect } from 'react';
 import { NodeData, NodeType, Connection, HandleType } from '../types';
-import { FileText, ScrollText, Users as UsersIcon, UserCog, PenTool, PenSquare, Edit3, Image, ImagePlus, Wand2, Sparkles, Trash2, ChevronDown, ChevronUp, Video, Clapperboard, Upload, Bot, Shuffle, Layers } from 'lucide-react';
+import { FileText, ScrollText, Users as UsersIcon, UserCog, PenTool, PenSquare, Edit3, Image, ImagePlus, Wand2, Sparkles, Trash2, ChevronDown, ChevronUp, Video, Clapperboard, Upload, Bot, Shuffle, Layers, BookOpen, ListChecks, LayoutPanelTop, RefreshCcw, Download, Film } from 'lucide-react';
 import NodeHandle from './NodeHandle';
 import { useTheme } from '../contexts/ThemeContext';
 import { areHandlesCompatible, NodeHandleSpec } from '../utils/node-spec';
@@ -37,6 +37,12 @@ interface NodeProps {
   onExpandStory: (nodeId: string) => void;
   onGenerateShortStory: (nodeId: string) => void;
   onGenerateScreenplay: (nodeId: string) => void;
+  onGenerateWorldBible: (nodeId: string) => void;
+  onGenerateSceneBeats: (nodeId: string) => void;
+  onGenerateShotPrompts: (nodeId: string) => void;
+  onGenerateVideoKeyframe: (nodeId: string) => void;
+  onSyncVideoSequence: (nodeId: string) => void;
+  onExportVideoSequence: (nodeId: string) => void;
   onOpenTextModal: (title: string, text: string) => void;
   onImageClick: (imageUrl: string) => void;
   onOutputMouseDown: (nodeId: string, handleId: string) => void;
@@ -140,6 +146,12 @@ const Node: React.FC<NodeProps> = ({
   onExpandStory,
   onGenerateShortStory,
   onGenerateScreenplay,
+  onGenerateWorldBible,
+  onGenerateSceneBeats,
+  onGenerateShotPrompts,
+  onGenerateVideoKeyframe,
+  onSyncVideoSequence,
+  onExportVideoSequence,
   onOpenTextModal,
   onImageClick,
   onOutputMouseDown,
@@ -266,6 +278,14 @@ const Node: React.FC<NodeProps> = ({
         onExpandStory(node.id);
       } else if (nodeType === NodeType.ScreenplayWriter) {
         onGenerateScreenplay(node.id);
+      } else if (nodeType === NodeType.WorldBible) {
+        onGenerateWorldBible(node.id);
+      } else if (nodeType === NodeType.SceneBeatPlanner) {
+        onGenerateSceneBeats(node.id);
+      } else if (nodeType === NodeType.ShotStoryboard) {
+        onGenerateShotPrompts(node.id);
+      } else if (nodeType === NodeType.VideoKeyframeInitializer) {
+        onGenerateVideoKeyframe(node.id);
       }
     }
   };
@@ -1343,6 +1363,603 @@ const Node: React.FC<NodeProps> = ({
         </>
       )}
       
+      {node.type === NodeType.WorldBible && (
+        <>
+          <NodeHeader
+            title='World Bible'
+            icon={<BookOpen className="w-4 h-4 text-sky-300" />}
+            isMinimized={isMinimized}
+            onToggleMinimize={() => onToggleMinimize(node.id)}
+            onDelete={handleDelete}
+            onShowDeleteConfirmation={handleShowDeleteConfirmation}
+            onMouseDown={handleHeaderMouseDown}
+            onContextMenu={handleHeaderContextMenu}
+          />
+          <div className={`transition-all duration-300 ease-in-out overflow-hidden ${isMinimized ? 'max-h-0 opacity-0' : 'max-h-[1200px] opacity-100'}`}>
+            <div className="p-2 space-y-3">
+              <div ref={el => handleAnchorRefs.current['world_prompt_input'] = el}>
+                <label htmlFor={`world-prompt-${node.id}`} className={labelClassName}>World Prompt</label>
+                <textarea
+                  id={`world-prompt-${node.id}`}
+                  value={node.data.worldPrompt || ''}
+                  onChange={(e) => onUpdateData(node.id, { worldPrompt: e.target.value })}
+                  onKeyDown={(e) => handleTextAreaKeyDown(e, NodeType.WorldBible)}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  className={`${textAreaClassName(connections.some(c => c.toNodeId === node.id && c.toHandleId === 'world_prompt_input'))} h-24`}
+                  disabled={connections.some(c => c.toNodeId === node.id && c.toHandleId === 'world_prompt_input')}
+                  placeholder="Describe the canon you want to establish..."
+                />
+              </div>
+
+              {node.data.error && (
+                <div className="text-xs text-red-400" role="alert">{node.data.error}</div>
+              )}
+
+              <div ref={el => handleAnchorRefs.current['world_summary_output'] = el}>
+                <label className={labelClassName}>World Summary</label>
+                <div className={`${imagePreviewBaseClassName} h-32 items-start`}>
+                  <ExpandableTextArea
+                    value={node.data.worldSummary || ''}
+                    placeholder="Summary will appear here..."
+                    className={`w-full h-full p-2 bg-transparent border-0 focus:outline-none focus:ring-0 resize-none custom-scrollbar text-xs leading-relaxed`}
+                    title="World Summary"
+                    containerClassName="w-full h-full"
+                    onOpenModal={onOpenTextModal}
+                  />
+                </div>
+              </div>
+
+              <div ref={el => handleAnchorRefs.current['key_locations_output'] = el}>
+                <label className={labelClassName}>Key Locations</label>
+                <div className={`${imagePreviewBaseClassName} h-28 items-start`}>
+                  <ExpandableTextArea
+                    value={node.data.keyLocations || ''}
+                    placeholder="Landmarks, regions, hubs..."
+                    className={`w-full h-full p-2 bg-transparent border-0 focus:outline-none focus:ring-0 resize-none custom-scrollbar text-xs leading-relaxed`}
+                    title="Key Locations"
+                    containerClassName="w-full h-full"
+                    onOpenModal={onOpenTextModal}
+                  />
+                </div>
+              </div>
+
+              <div ref={el => handleAnchorRefs.current['factions_output'] = el}>
+                <label className={labelClassName}>Factions & Cast</label>
+                <div className={`${imagePreviewBaseClassName} h-28 items-start`}>
+                  <ExpandableTextArea
+                    value={node.data.factionsAndAllies || ''}
+                    placeholder="Factions, power groups, key characters..."
+                    className={`w-full h-full p-2 bg-transparent border-0 focus:outline-none focus:ring-0 resize-none custom-scrollbar text-xs leading-relaxed`}
+                    title="Factions and Cast"
+                    containerClassName="w-full h-full"
+                    onOpenModal={onOpenTextModal}
+                  />
+                </div>
+              </div>
+
+              <div ref={el => handleAnchorRefs.current['visual_motifs_output'] = el}>
+                <label className={labelClassName}>Visual Motifs</label>
+                <div className={`${imagePreviewBaseClassName} h-28 items-start`}>
+                  <ExpandableTextArea
+                    value={node.data.visualMotifs || ''}
+                    placeholder="Color palettes, lighting cues, stylistic notes..."
+                    className={`w-full h-full p-2 bg-transparent border-0 focus:outline-none focus:ring-0 resize-none custom-scrollbar text-xs leading-relaxed`}
+                    title="Visual Motifs"
+                    containerClassName="w-full h-full"
+                    onOpenModal={onOpenTextModal}
+                  />
+                </div>
+              </div>
+
+              <div ref={el => handleAnchorRefs.current['continuity_rules_output'] = el}>
+                <label className={labelClassName}>Continuity Rules</label>
+                <div className={`${imagePreviewBaseClassName} h-28 items-start`}>
+                  <ExpandableTextArea
+                    value={node.data.continuityRules || ''}
+                    placeholder="Tone guardrails, forbidden elements, do's and don'ts..."
+                    className={`w-full h-full p-2 bg-transparent border-0 focus:outline-none focus:ring-0 resize-none custom-scrollbar text-xs leading-relaxed`}
+                    title="Continuity Rules"
+                    containerClassName="w-full h-full"
+                    onOpenModal={onOpenTextModal}
+                  />
+                </div>
+              </div>
+
+              <button
+                onClick={() => onGenerateWorldBible(node.id)}
+                disabled={node.data.isLoading}
+                className={`w-full flex items-center justify-center p-2 ${node.data.isLoading ? 'bg-gray-600' : 'bg-sky-600 hover:bg-sky-500'} text-white font-bold rounded-md transition-colors text-sm disabled:cursor-not-allowed`}
+              >
+                <Sparkles className={`w-4 h-4 mr-2 ${node.data.isLoading ? 'animate-pulse' : ''}`} />
+                {node.data.isLoading ? 'Generating...' : 'Generate Bible'}
+              </button>
+            </div>
+          </div>
+          {isMinimized && (
+            <div className={`p-2 h-16 text-xs italic ${styles.node.labelText} truncate rounded-b-md flex items-center border-t ${styles.node.border}`}>
+              {node.data.worldSummary ? node.data.worldSummary : 'No world bible generated yet.'}
+            </div>
+          )}
+        </>
+      )}
+
+      {node.type === NodeType.SceneBeatPlanner && (
+        <>
+          <NodeHeader
+            title='Scene Beat Planner'
+            icon={<ListChecks className="w-4 h-4 text-emerald-300" />}
+            isMinimized={isMinimized}
+            onToggleMinimize={() => onToggleMinimize(node.id)}
+            onDelete={handleDelete}
+            onShowDeleteConfirmation={handleShowDeleteConfirmation}
+            onMouseDown={handleHeaderMouseDown}
+            onContextMenu={handleHeaderContextMenu}
+          />
+          <div className={`transition-all duration-300 ease-in-out overflow-hidden ${isMinimized ? 'max-h-0 opacity-0' : 'max-h-[1200px] opacity-100'}`}>
+            <div className="p-2 space-y-3">
+              <div ref={el => handleAnchorRefs.current['story_input'] = el}>
+                <label htmlFor={`scene-input-${node.id}`} className={labelClassName}>Story Input</label>
+                <textarea
+                  id={`scene-input-${node.id}`}
+                  value={node.data.scenePlannerInput || ''}
+                  onChange={(e) => onUpdateData(node.id, { scenePlannerInput: e.target.value })}
+                  onKeyDown={(e) => handleTextAreaKeyDown(e, NodeType.SceneBeatPlanner)}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  className={`${textAreaClassName(connections.some(c => c.toNodeId === node.id && c.toHandleId === 'story_input'))} h-28`}
+                  disabled={connections.some(c => c.toNodeId === node.id && c.toHandleId === 'story_input')}
+                  placeholder="Paste a synopsis or story excerpt to break into beats..."
+                />
+              </div>
+
+              <div>
+                <label htmlFor={`structure-${node.id}`} className={labelClassName}>Structure Preset</label>
+                <select
+                  id={`structure-${node.id}`}
+                  value={node.data.structurePreset || 'three_act'}
+                  onChange={(e) => onUpdateData(node.id, { structurePreset: e.target.value })}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  className={selectClassName}
+                >
+                  <option value="three_act">Three-Act Structure</option>
+                  <option value="hero_journey">Hero&apos;s Journey</option>
+                </select>
+              </div>
+
+              {node.data.error && (
+                <div className="text-xs text-red-400" role="alert">{node.data.error}</div>
+              )}
+
+              <div ref={el => handleAnchorRefs.current['scene_beats_output'] = el}>
+                <label className={labelClassName}>Scene Beats</label>
+                <div className={`${imagePreviewBaseClassName} h-40 items-start`}>
+                  {node.data.isLoading ? (
+                    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-emerald-300 mt-16"></div>
+                  ) : (
+                    <ExpandableTextArea
+                      value={node.data.sceneBeatsText || ''}
+                      placeholder="Beats will appear here..."
+                      className={`w-full h-full p-2 bg-transparent border-0 focus:outline-none focus:ring-0 resize-none custom-scrollbar text-xs leading-relaxed`}
+                      title="Scene Beats"
+                      containerClassName="w-full h-full"
+                      onOpenModal={onOpenTextModal}
+                    />
+                  )}
+                </div>
+              </div>
+
+              <div ref={el => handleAnchorRefs.current['asset_checklist_output'] = el}>
+                <label className={labelClassName}>Asset Checklist</label>
+                <div className={`${imagePreviewBaseClassName} h-28 items-start`}>
+                  <ExpandableTextArea
+                    value={node.data.assetChecklistText || ''}
+                    placeholder="Props, FX, costumes..."
+                    className={`w-full h-full p-2 bg-transparent border-0 focus:outline-none focus:ring-0 resize-none custom-scrollbar text-xs leading-relaxed`}
+                    title="Asset Checklist"
+                    containerClassName="w-full h-full"
+                    onOpenModal={onOpenTextModal}
+                  />
+                </div>
+              </div>
+
+              <button
+                onClick={() => onGenerateSceneBeats(node.id)}
+                disabled={node.data.isLoading}
+                className={`w-full flex items-center justify-center p-2 ${node.data.isLoading ? 'bg-gray-600' : 'bg-emerald-600 hover:bg-emerald-500'} text-white font-bold rounded-md transition-colors text-sm disabled:cursor-not-allowed`}
+              >
+                <Sparkles className={`w-4 h-4 mr-2 ${node.data.isLoading ? 'animate-pulse' : ''}`} />
+                {node.data.isLoading ? 'Breaking Down...' : 'Generate Scene Beats'}
+              </button>
+            </div>
+          </div>
+          {isMinimized && (
+            <div className={`p-2 h-16 text-xs italic ${styles.node.labelText} truncate rounded-b-md flex items-center border-t ${styles.node.border}`}>
+              {node.data.sceneBeats && node.data.sceneBeats.length > 0 ? `${node.data.sceneBeats.length} beats ready.` : 'No beats generated yet.'}
+            </div>
+          )}
+        </>
+      )}
+
+      {node.type === NodeType.ShotStoryboard && (
+        <>
+          <NodeHeader
+            title='Shot Storyboard'
+            icon={<LayoutPanelTop className="w-4 h-4 text-pink-300" />}
+            isMinimized={isMinimized}
+            onToggleMinimize={() => onToggleMinimize(node.id)}
+            onDelete={handleDelete}
+            onShowDeleteConfirmation={handleShowDeleteConfirmation}
+            onMouseDown={handleHeaderMouseDown}
+            onContextMenu={handleHeaderContextMenu}
+          />
+          <div className={`transition-all duration-300 ease-in-out overflow-hidden ${isMinimized ? 'max-h-0 opacity-0' : 'max-h-[1200px] opacity-100'}`}>
+            <div className="p-2 space-y-3">
+              <div ref={el => handleAnchorRefs.current['beat_input'] = el}>
+                <label htmlFor={`shot-beat-${node.id}`} className={labelClassName}>Scene Beat</label>
+                <textarea
+                  id={`shot-beat-${node.id}`}
+                  value={node.data.shotReferenceText || ''}
+                  onChange={(e) => onUpdateData(node.id, { shotReferenceText: e.target.value })}
+                  onKeyDown={(e) => handleTextAreaKeyDown(e, NodeType.ShotStoryboard)}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  className={`${textAreaClassName(connections.some(c => c.toNodeId === node.id && c.toHandleId === 'beat_input'))} h-24`}
+                  disabled={connections.some(c => c.toNodeId === node.id && c.toHandleId === 'beat_input')}
+                  placeholder="Describe the beat you want to visualize..."
+                />
+              </div>
+
+              <div>
+                <label htmlFor={`shot-style-${node.id}`} className={labelClassName}>Style Guide</label>
+                <textarea
+                  id={`shot-style-${node.id}`}
+                  value={node.data.shotStyleGuide || ''}
+                  onChange={(e) => onUpdateData(node.id, { shotStyleGuide: e.target.value })}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  className={`${textAreaClassName()} h-20`}
+                  placeholder="Camera language, lenses, lighting inspirations..."
+                />
+              </div>
+
+              {node.data.error && (
+                <div className="text-xs text-red-400" role="alert">{node.data.error}</div>
+              )}
+
+              <div ref={el => handleAnchorRefs.current['shot_prompts_output'] = el}>
+                <label className={labelClassName}>Shot Prompts</label>
+                <div className={`${imagePreviewBaseClassName} h-48 items-start`}>
+                  {node.data.isLoading ? (
+                    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-pink-300 mt-20"></div>
+                  ) : (
+                    <ExpandableTextArea
+                      value={node.data.shotPromptsText || ''}
+                      placeholder="Shot breakdown will appear here..."
+                      className={`w-full h-full p-2 bg-transparent border-0 focus:outline-none focus:ring-0 resize-none custom-scrollbar text-xs leading-relaxed`}
+                      title="Shot Prompts"
+                      containerClassName="w-full h-full"
+                      onOpenModal={onOpenTextModal}
+                    />
+                  )}
+                </div>
+              </div>
+
+              <button
+                onClick={() => onGenerateShotPrompts(node.id)}
+                disabled={node.data.isLoading}
+                className={`w-full flex items-center justify-center p-2 ${node.data.isLoading ? 'bg-gray-600' : 'bg-pink-600 hover:bg-pink-500'} text-white font-bold rounded-md transition-colors text-sm disabled:cursor-not-allowed`}
+              >
+                <Sparkles className={`w-4 h-4 mr-2 ${node.data.isLoading ? 'animate-pulse' : ''}`} />
+                {node.data.isLoading ? 'Storyboarding...' : 'Generate Shot Prompts'}
+              </button>
+            </div>
+          </div>
+          {isMinimized && (
+            <div className={`p-2 h-16 text-xs italic ${styles.node.labelText} truncate rounded-b-md flex items-center border-t ${styles.node.border}`}>
+              {node.data.shotPrompts && node.data.shotPrompts.length > 0 ? `${node.data.shotPrompts.length} shots outlined.` : 'No shot prompts yet.'}
+            </div>
+          )}
+        </>
+      )}
+
+      {node.type === NodeType.VideoKeyframeInitializer && (() => {
+        const referenceHandles = [
+          { id: 'character_ref_input', label: 'Character Ref' },
+          { id: 'location_ref_input', label: 'Location Ref' },
+          { id: 'continuity_ref_input', label: 'Continuity Frame' },
+        ];
+
+        const getImageForHandle = (handleId: string): string | null => {
+          const related = connections.filter(conn => conn.toNodeId === node.id && conn.toHandleId === handleId);
+          for (const conn of related) {
+            const upstreamNode = allNodes.find(n => n.id === conn.fromNodeId);
+            if (!upstreamNode) continue;
+
+            if (upstreamNode.type === NodeType.ImageGenerator && upstreamNode.data.imageUrls) {
+              const match = conn.fromHandleId.match(/_(\d+)$/);
+              if (match) {
+                const index = parseInt(match[1], 10) - 1;
+                const url = upstreamNode.data.imageUrls[index];
+                if (url) return url;
+              }
+            } else if (upstreamNode.type === NodeType.VideoKeyframeInitializer && upstreamNode.data.keyframeImageUrl) {
+              return upstreamNode.data.keyframeImageUrl;
+            } else if (typeof upstreamNode.data.imageUrl === 'string') {
+              return upstreamNode.data.imageUrl;
+            } else if (typeof upstreamNode.data.inputImageUrl === 'string') {
+              return upstreamNode.data.inputImageUrl;
+            }
+          }
+          return null;
+        };
+
+        return (
+          <>
+            <NodeHeader
+              title='Video Keyframe Init'
+              icon={<Sparkles className="w-4 h-4 text-amber-300" />}
+              isMinimized={isMinimized}
+              onToggleMinimize={() => onToggleMinimize(node.id)}
+              onDelete={handleDelete}
+              onShowDeleteConfirmation={handleShowDeleteConfirmation}
+              onMouseDown={handleHeaderMouseDown}
+              onContextMenu={handleHeaderContextMenu}
+            />
+            <div className={`transition-all duration-300 ease-in-out overflow-hidden ${isMinimized ? 'max-h-0 opacity-0' : 'max-h-[1000px] opacity-100'}`}>
+              <div className="p-2 space-y-3">
+                <div className="grid grid-cols-1 gap-2 md:grid-cols-3">
+                  {referenceHandles.map(slot => {
+                    const imageUrl = getImageForHandle(slot.id);
+                    return (
+                      <div key={slot.id} ref={el => handleAnchorRefs.current[slot.id] = el}>
+                        <label className={labelClassName}>{slot.label}</label>
+                        <div className={`${imagePreviewBaseClassName} h-24`}>
+                          {imageUrl ? (
+                            <img src={imageUrl} alt={slot.label} className="w-full h-full object-cover rounded-md" />
+                          ) : (
+                            <div className="text-xs text-center px-2 opacity-70 flex items-center justify-center h-full">Connect an image</div>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                <div ref={el => handleAnchorRefs.current['prompt_input'] = el}>
+                  <label htmlFor={`keyframe-prompt-${node.id}`} className={labelClassName}>Keyframe Prompt</label>
+                  <textarea
+                    id={`keyframe-prompt-${node.id}`}
+                    value={node.data.keyframePrompt || ''}
+                    onChange={(e) => onUpdateData(node.id, { keyframePrompt: e.target.value })}
+                    onKeyDown={(e) => handleTextAreaKeyDown(e, NodeType.VideoKeyframeInitializer)}
+                    onMouseDown={(e) => e.stopPropagation()}
+                    className={`${textAreaClassName(connections.some(c => c.toNodeId === node.id && c.toHandleId === 'prompt_input'))} h-20`}
+                    disabled={connections.some(c => c.toNodeId === node.id && c.toHandleId === 'prompt_input')}
+                    placeholder="Blend references into a cinematic establishing shot..."
+                  />
+                </div>
+
+                <div ref={el => handleAnchorRefs.current['keyframe_image_output'] = el}>
+                  <label className={labelClassName}>Generated Keyframe</label>
+                  <div className={`${imagePreviewBaseClassName} h-48`}>
+                    {node.data.isLoading ? (
+                      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-amber-300 mt-20"></div>
+                    ) : node.data.error ? (
+                      <div className="text-red-400 text-xs p-2 text-center">{node.data.error}</div>
+                    ) : node.data.keyframeImageUrl ? (
+                      <img
+                        src={node.data.keyframeImageUrl}
+                        alt="Keyframe"
+                        className="w-full h-full object-cover rounded-md cursor-zoom-in"
+                        onClick={() => onImageClick(node.data.keyframeImageUrl!)}
+                      />
+                    ) : (
+                      <div className="text-xs text-center px-2 opacity-70 flex items-center justify-center h-full">Run the keyframe generator to preview the blended frame.</div>
+                    )}
+                  </div>
+                </div>
+
+                <button
+                  onClick={() => onGenerateVideoKeyframe(node.id)}
+                  disabled={node.data.isLoading}
+                  className={`w-full flex items-center justify-center p-2 ${node.data.isLoading ? 'bg-gray-600' : 'bg-amber-500 hover:bg-amber-400'} text-white font-bold rounded-md transition-colors text-sm disabled:cursor-not-allowed`}
+                >
+                  <Sparkles className={`w-4 h-4 mr-2 ${node.data.isLoading ? 'animate-pulse' : ''}`} />
+                  {node.data.isLoading ? 'Synthesizing...' : 'Generate Keyframe'}
+                </button>
+              </div>
+            </div>
+            {isMinimized && (
+              <div className={`w-full ${styles.node.imagePlaceholderBg} rounded-b-md flex items-center justify-center border-t ${styles.node.imagePlaceholderBorder} transition-all duration-300 ease-in-out overflow-hidden`}
+                style={{ height: node.data.minimizedHeight ? `${node.data.minimizedHeight}px` : '64px' }}
+              >
+                {node.data.keyframeImageUrl ? (
+                  <img key={node.data.keyframeImageUrl} ref={minimizedImageRef} src={node.data.keyframeImageUrl} alt="Keyframe preview" className="w-full h-full object-contain" />
+                ) : (
+                  <Sparkles className={`w-8 h-8 ${styles.node.imagePlaceholderIcon}`} />
+                )}
+              </div>
+            )}
+          </>
+        );
+      })()}
+
+      {node.type === NodeType.VideoSequencePlanner && (() => {
+        const clips = node.data.timelineClips || [];
+        const handleClipChange = (index: number, partial: Partial<TimelineClipPlan>) => {
+          const updatedClips = [...clips];
+          updatedClips[index] = { ...updatedClips[index], ...partial };
+          onUpdateData(node.id, { timelineClips: updatedClips });
+        };
+
+        const clipConnections = connections.filter(conn => conn.toNodeId === node.id && conn.toHandleId === 'clip_input');
+
+        return (
+          <>
+            <NodeHeader
+              title='Video Sequence Planner'
+              icon={<Film className="w-4 h-4 text-indigo-300" />}
+              isMinimized={isMinimized}
+              onToggleMinimize={() => onToggleMinimize(node.id)}
+              onDelete={handleDelete}
+              onShowDeleteConfirmation={handleShowDeleteConfirmation}
+              onMouseDown={handleHeaderMouseDown}
+              onContextMenu={handleHeaderContextMenu}
+            />
+            <div className={`transition-all duration-300 ease-in-out overflow-hidden ${isMinimized ? 'max-h-0 opacity-0' : 'max-h-[1400px] opacity-100'}`}>
+              <div className="p-2 space-y-3">
+                <div className="flex items-center justify-between gap-2">
+                  <button
+                    onClick={() => onSyncVideoSequence(node.id)}
+                    className={`flex items-center px-3 py-2 rounded-md text-sm font-semibold ${styles.node.inputBg} border ${styles.node.inputBorder} ${styles.node.text} hover:ring-2 focus:outline-none ${styles.node.inputFocusRing}`}
+                  >
+                    <RefreshCcw className="w-4 h-4 mr-2" />
+                    Sync Clips
+                  </button>
+                  <button
+                    onClick={() => onExportVideoSequence(node.id)}
+                    className={`flex items-center px-3 py-2 rounded-md text-sm font-semibold bg-indigo-600 hover:bg-indigo-500 text-white`}
+                  >
+                    <Download className="w-4 h-4 mr-2" />
+                    Export Timeline
+                  </button>
+                </div>
+
+                <div ref={el => handleAnchorRefs.current['clip_input'] = el} className={`${styles.node.inputBg} border ${styles.node.inputBorder} rounded-md p-2 space-y-2`}>
+                  <div className={`${labelClassName} uppercase tracking-wide`}>Connected Clips</div>
+                  {clipConnections.length === 0 ? (
+                    <div className="text-xs italic opacity-70">Connect video outputs to plan a sequence.</div>
+                  ) : (
+                    clipConnections.map((conn, index) => {
+                      const clipNode = allNodes.find(n => n.id === conn.fromNodeId);
+                      return (
+                        <div key={conn.id} className="text-xs flex justify-between items-center bg-black/20 rounded px-2 py-1">
+                          <span className="truncate">{clipNode?.data.editDescription || `Video ${index + 1}`}</span>
+                          <span className="opacity-60">{clipNode?.id}</span>
+                        </div>
+                      );
+                    })
+                  )}
+                </div>
+
+                {clips.length === 0 ? (
+                  <div className="text-xs italic opacity-70">Sync clips to start assembling the timeline.</div>
+                ) : (
+                  <div className="space-y-3">
+                    {clips.map((clip, index) => (
+                      <div key={clip.clipNodeId} className={`rounded-md border ${styles.node.border} ${styles.node.inputBg} p-2 space-y-2`}>
+                        <div className="flex items-center justify-between">
+                          <span className="text-xs uppercase opacity-70">Clip {index + 1}</span>
+                          <span className="text-[10px] opacity-60">{clip.clipNodeId}</span>
+                        </div>
+                        <input
+                          type="text"
+                          value={clip.clipLabel}
+                          onChange={(e) => handleClipChange(index, { clipLabel: e.target.value })}
+                          onMouseDown={(e) => e.stopPropagation()}
+                          className={`w-full px-2 py-1 rounded border ${styles.node.inputBorder} ${styles.node.inputBg} ${styles.node.text} text-sm`}
+                          placeholder="Clip label"
+                        />
+                        <div className="grid grid-cols-2 gap-2">
+                          <div>
+                            <label className={labelClassName}>Duration (sec)</label>
+                            <input
+                              type="number"
+                              min={0}
+                              value={clip.durationSeconds ?? ''}
+                              onChange={(e) => handleClipChange(index, { durationSeconds: e.target.value ? Number(e.target.value) : undefined })}
+                              onMouseDown={(e) => e.stopPropagation()}
+                              className={`w-full px-2 py-1 rounded border ${styles.node.inputBorder} ${styles.node.inputBg} ${styles.node.text} text-sm`}
+                              placeholder="e.g., 6"
+                            />
+                          </div>
+                          <div>
+                            <label className={labelClassName}>Transition</label>
+                            <input
+                              type="text"
+                              value={clip.transition || ''}
+                              onChange={(e) => handleClipChange(index, { transition: e.target.value })}
+                              onMouseDown={(e) => e.stopPropagation()}
+                              className={`w-full px-2 py-1 rounded border ${styles.node.inputBorder} ${styles.node.inputBg} ${styles.node.text} text-sm`}
+                              placeholder="Cut, dissolve, whip pan..."
+                            />
+                          </div>
+                        </div>
+                        <div>
+                          <label className={labelClassName}>Notes</label>
+                          <textarea
+                            value={clip.notes || ''}
+                            onChange={(e) => handleClipChange(index, { notes: e.target.value })}
+                            onMouseDown={(e) => e.stopPropagation()}
+                            className={`${textAreaClassName()} h-16`}
+                            placeholder="Camera direction, VFX reminders, dialogue cues..."
+                          />
+                        </div>
+                        {clip.prompt && (
+                          <div>
+                            <label className={labelClassName}>Source Prompt</label>
+                            <div className={`${imagePreviewBaseClassName} h-24 items-start`}>
+                              <ExpandableTextArea
+                                value={clip.prompt || ''}
+                                placeholder="Prompt"
+                                className={`w-full h-full p-2 bg-transparent border-0 focus:outline-none focus:ring-0 resize-none custom-scrollbar text-xs leading-relaxed`}
+                                title={`Clip ${index + 1} Prompt`}
+                                containerClassName="w-full h-full"
+                                onOpenModal={onOpenTextModal}
+                              />
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                <div>
+                  <label className={labelClassName}>Music Cue</label>
+                  <input
+                    type="text"
+                    value={node.data.musicCue || ''}
+                    onChange={(e) => onUpdateData(node.id, { musicCue: e.target.value })}
+                    onMouseDown={(e) => e.stopPropagation()}
+                    className={`w-full px-2 py-1 rounded border ${styles.node.inputBorder} ${styles.node.inputBg} ${styles.node.text} text-sm`}
+                    placeholder="Atmospheric synth swell, percussive hits..."
+                  />
+                </div>
+
+                <div ref={el => handleAnchorRefs.current['notes_input'] = el}>
+                  <label className={labelClassName}>Timeline Notes</label>
+                  <textarea
+                    value={node.data.timelineNotes || ''}
+                    onChange={(e) => onUpdateData(node.id, { timelineNotes: e.target.value })}
+                    onMouseDown={(e) => e.stopPropagation()}
+                    className={`${textAreaClassName(connections.some(c => c.toNodeId === node.id && c.toHandleId === 'notes_input'))} h-20`}
+                    disabled={connections.some(c => c.toNodeId === node.id && c.toHandleId === 'notes_input')}
+                    placeholder="Global pacing notes, act breaks, graphics overlays..."
+                  />
+                </div>
+
+                <div ref={el => handleAnchorRefs.current['timeline_output'] = el}>
+                  <label className={labelClassName}>Exported Timeline</label>
+                  <div className={`${imagePreviewBaseClassName} h-40 items-start`}>
+                    <ExpandableTextArea
+                      value={node.data.timelineExportText || ''}
+                      placeholder="Export JSON will appear here after running Export Timeline."
+                      className={`w-full h-full p-2 bg-transparent border-0 focus:outline-none focus:ring-0 resize-none custom-scrollbar text-xs leading-relaxed`}
+                      title="Timeline Export"
+                      containerClassName="w-full h-full"
+                      onOpenModal={onOpenTextModal}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            {isMinimized && (
+              <div className={`p-2 h-16 text-xs italic ${styles.node.labelText} truncate rounded-b-md flex items-center border-t ${styles.node.border}`}>
+                {clips.length > 0 ? `${clips.length} clips synchronized.` : 'No clips synchronized yet.'}
+              </div>
+            )}
+          </>
+        );
+      })()}
+
       {node.type === NodeType.ImageEditor && (
         <>
             <NodeHeader

--- a/components/Toolbar.tsx
+++ b/components/Toolbar.tsx
@@ -28,10 +28,15 @@ interface ToolbarProps {
   onAddStoryExpanderNode: () => void;
   onAddShortStoryWriterNode: () => void;
   onAddScreenplayWriterNode: () => void;
+  onAddWorldBibleNode: () => void;
+  onAddSceneBeatPlannerNode: () => void;
+  onAddShotStoryboardNode: () => void;
   onAddImageNode: () => void;
   onAddImageEditorNode: () => void;
   onAddImageMixerNode: () => void;
   onAddVideoGeneratorNode: () => void;
+  onAddVideoKeyframeInitializerNode: () => void;
+  onAddVideoSequencePlannerNode: () => void;
   onUndo: () => void;
   onRedo: () => void;
   canUndo: boolean;
@@ -86,10 +91,15 @@ const Toolbar: React.FC<ToolbarProps> = ({
     onAddStoryExpanderNode,
     onAddShortStoryWriterNode,
     onAddScreenplayWriterNode,
+    onAddWorldBibleNode,
+    onAddSceneBeatPlannerNode,
+    onAddShotStoryboardNode,
     onAddImageNode,
     onAddImageEditorNode,
     onAddImageMixerNode,
     onAddVideoGeneratorNode,
+    onAddVideoKeyframeInitializerNode,
+    onAddVideoSequencePlannerNode,
     onUndo,
     onRedo,
     canUndo,
@@ -164,9 +174,14 @@ const Toolbar: React.FC<ToolbarProps> = ({
     onAddStoryExpanderNode,
     onAddShortStoryWriterNode,
     onAddScreenplayWriterNode,
+    onAddWorldBibleNode,
+    onAddSceneBeatPlannerNode,
+    onAddShotStoryboardNode,
     onAddImageEditorNode,
     onAddImageMixerNode,
     onAddVideoGeneratorNode,
+    onAddVideoKeyframeInitializerNode,
+    onAddVideoSequencePlannerNode,
   }), [
     onAddTextNode,
     onAddTextGeneratorNode,
@@ -177,9 +192,14 @@ const Toolbar: React.FC<ToolbarProps> = ({
     onAddStoryExpanderNode,
     onAddShortStoryWriterNode,
     onAddScreenplayWriterNode,
+    onAddWorldBibleNode,
+    onAddSceneBeatPlannerNode,
+    onAddShotStoryboardNode,
     onAddImageEditorNode,
     onAddImageMixerNode,
     onAddVideoGeneratorNode,
+    onAddVideoKeyframeInitializerNode,
+    onAddVideoSequencePlannerNode,
   ]);
 
   const storyToolsCategory = useMemo(() => buildStoryToolsCategory({
@@ -192,15 +212,32 @@ const Toolbar: React.FC<ToolbarProps> = ({
     onAddStoryExpanderNode,
     onAddShortStoryWriterNode,
     onAddScreenplayWriterNode,
+    onAddWorldBibleNode,
+    onAddSceneBeatPlannerNode,
+    onAddShotStoryboardNode,
     onAddImageEditorNode,
     onAddImageMixerNode,
     onAddVideoGeneratorNode,
+    onAddVideoKeyframeInitializerNode,
+    onAddVideoSequencePlannerNode,
   }), [
     onAddCharacterGeneratorNode,
     onAddStoryCharacterCreatorNode,
     onAddStoryExpanderNode,
     onAddShortStoryWriterNode,
     onAddScreenplayWriterNode,
+    onAddWorldBibleNode,
+    onAddSceneBeatPlannerNode,
+    onAddShotStoryboardNode,
+    onAddImageGeneratorNode,
+    onAddTextNode,
+    onAddTextGeneratorNode,
+    onAddImageNode,
+    onAddImageEditorNode,
+    onAddImageMixerNode,
+    onAddVideoGeneratorNode,
+    onAddVideoKeyframeInitializerNode,
+    onAddVideoSequencePlannerNode,
   ]);
 
   const createProjectActionHandler = (action: () => void | boolean | Promise<void | boolean>) => () => {

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
 </head>
   <body class="bg-gray-900">
     <div id="root"></div>
-    <script src="/env.js"></script>
+    <script type="module" src="/env.js"></script>
     <script type="module" src="/index.tsx"></script>
   </body>
 </html>

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,6 +1,7 @@
 
 
 import { GoogleGenAI, Modality, Type } from "@google/genai";
+import { SceneBeat, ShotPrompt, WorldBibleSections } from "../types";
 
 // The API key is loaded from env.js, which should be created in the project root.
 const getApiKey = (): string | undefined => {
@@ -213,6 +214,299 @@ Return the result as a single JSON object with two keys: "pitch" and "screenplay
             }
 
             return { pitch: parsed.pitch, screenplay: parsed.screenplay };
+        } catch (error) {
+            lastError = error;
+            console.error(`Attempt ${attempt} failed:`, error);
+            if (attempt < MAX_RETRIES) {
+                await sleep(INITIAL_DELAY_MS * Math.pow(2, attempt - 1));
+            }
+        }
+    }
+
+    throw new Error(getFriendlyErrorMessage(lastError));
+};
+
+export const generateWorldBible = async (
+    worldPrompt: string
+): Promise<WorldBibleSections> => {
+    if (!ai) {
+        throw new Error("API Key is not configured. Please add your key to the `env.js` file in the project root.");
+    }
+
+    const trimmedPrompt = worldPrompt?.trim();
+    if (!trimmedPrompt) {
+        throw new Error('Please provide a world prompt.');
+    }
+
+    const prompt = `You are the showrunner's worldbuilding assistant. Given the following directive, produce a concise canon bible that downstream art and writing teams can rely on. Keep each section to 2-4 tight paragraphs packed with evocative, production-ready detail.
+
+Directive: "${trimmedPrompt}"
+
+Return JSON with the keys: worldSummary, keyLocations, factions, visualMotifs, continuityRules. Use markdown-friendly bullet points where helpful but keep each value a single string.`;
+
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        try {
+            const response = await ai.models.generateContent({
+                model: 'gemini-2.5-flash',
+                contents: prompt,
+                config: {
+                    responseMimeType: 'application/json',
+                    responseSchema: {
+                        type: Type.OBJECT,
+                        properties: {
+                            worldSummary: { type: Type.STRING },
+                            keyLocations: { type: Type.STRING },
+                            factions: { type: Type.STRING },
+                            visualMotifs: { type: Type.STRING },
+                            continuityRules: { type: Type.STRING },
+                        },
+                        required: ['worldSummary', 'keyLocations', 'factions', 'visualMotifs', 'continuityRules'],
+                    },
+                },
+            });
+
+            const text = response.text;
+            if (!text) {
+                throw new Error('The model returned an empty response.');
+            }
+
+            let parsed: Partial<WorldBibleSections & { factions?: unknown }> = {};
+            try {
+                parsed = JSON.parse(text);
+            } catch (parseError) {
+                throw new Error('The model returned an invalid world bible format.');
+            }
+
+            return {
+                worldSummary: typeof parsed.worldSummary === 'string' ? parsed.worldSummary : '',
+                keyLocations: typeof parsed.keyLocations === 'string' ? parsed.keyLocations : '',
+                factions: typeof parsed.factions === 'string' ? parsed.factions : '',
+                visualMotifs: typeof parsed.visualMotifs === 'string' ? parsed.visualMotifs : '',
+                continuityRules: typeof parsed.continuityRules === 'string' ? parsed.continuityRules : '',
+            };
+        } catch (error) {
+            lastError = error;
+            console.error(`Attempt ${attempt} failed:`, error);
+            if (attempt < MAX_RETRIES) {
+                await sleep(INITIAL_DELAY_MS * Math.pow(2, attempt - 1));
+            }
+        }
+    }
+
+    throw new Error(getFriendlyErrorMessage(lastError));
+};
+
+export const generateSceneBeats = async (
+    story: string,
+    structurePreset: string
+): Promise<{ beats: SceneBeat[]; assetChecklist: string[] }> => {
+    if (!ai) {
+        throw new Error("API Key is not configured. Please add your key to the `env.js` file in the project root.");
+    }
+
+    const trimmedStory = story?.trim();
+    if (!trimmedStory) {
+        throw new Error('Please provide story text to plan scenes.');
+    }
+
+    const structureHint = structurePreset === 'hero_journey'
+        ? 'Follow the twelve-step Hero’s Journey while grouping beats into clear scenes.'
+        : 'Use a tight three-act television structure with clear setup, confrontation, and resolution beats.';
+
+    const prompt = `You are a narrative producer breaking down material for a storyboard department. Analyse the provided story or synopsis and outline a sequence of production-ready scene beats.
+
+Story Input:
+"""
+${trimmedStory}
+"""
+
+Guidelines:
+- ${structureHint}
+- Each beat should have a short title, a 1-2 sentence summary, the setting, key characters, the protagonist goal, the central conflict or obstacle, and cinematography notes.
+- Identify concrete visual assets (characters, props, locations, FX) needed to realise the beat.
+
+Return JSON with two keys: "beats" (an array of beat objects) and "assetChecklist" (a de-duplicated array of production assets).`;
+
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        try {
+            const response = await ai.models.generateContent({
+                model: 'gemini-2.5-flash',
+                contents: prompt,
+                config: {
+                    responseMimeType: 'application/json',
+                    responseSchema: {
+                        type: Type.OBJECT,
+                        properties: {
+                            beats: {
+                                type: Type.ARRAY,
+                                items: {
+                                    type: Type.OBJECT,
+                                    properties: {
+                                        id: { type: Type.STRING },
+                                        title: { type: Type.STRING },
+                                        summary: { type: Type.STRING },
+                                        setting: { type: Type.STRING },
+                                        characters: {
+                                            type: Type.ARRAY,
+                                            items: { type: Type.STRING },
+                                        },
+                                        goal: { type: Type.STRING },
+                                        conflict: { type: Type.STRING },
+                                        visualNotes: { type: Type.STRING },
+                                        requiredAssets: {
+                                            type: Type.ARRAY,
+                                            items: { type: Type.STRING },
+                                        },
+                                    },
+                                    required: ['title', 'summary', 'setting', 'characters', 'goal', 'conflict', 'visualNotes', 'requiredAssets'],
+                                },
+                            },
+                            assetChecklist: {
+                                type: Type.ARRAY,
+                                items: { type: Type.STRING },
+                            },
+                        },
+                        required: ['beats', 'assetChecklist'],
+                    },
+                },
+            });
+
+            const text = response.text;
+            if (!text) {
+                throw new Error('The model returned an empty response.');
+            }
+
+            let parsed: any;
+            try {
+                parsed = JSON.parse(text);
+            } catch (parseError) {
+                throw new Error('The model returned an invalid scene beat format.');
+            }
+
+            const beats: SceneBeat[] = Array.isArray(parsed?.beats)
+                ? parsed.beats.map((beat: any, index: number): SceneBeat => ({
+                    id: typeof beat?.id === 'string' && beat.id.trim() ? beat.id : `beat_${index + 1}`,
+                    title: typeof beat?.title === 'string' ? beat.title : `Beat ${index + 1}`,
+                    summary: typeof beat?.summary === 'string' ? beat.summary : '',
+                    setting: typeof beat?.setting === 'string' ? beat.setting : '',
+                    characters: Array.isArray(beat?.characters) ? beat.characters.filter((c: unknown): c is string => typeof c === 'string') : [],
+                    goal: typeof beat?.goal === 'string' ? beat.goal : '',
+                    conflict: typeof beat?.conflict === 'string' ? beat.conflict : '',
+                    visualNotes: typeof beat?.visualNotes === 'string' ? beat.visualNotes : '',
+                    requiredAssets: Array.isArray(beat?.requiredAssets) ? beat.requiredAssets.filter((a: unknown): a is string => typeof a === 'string') : [],
+                }))
+                : [];
+
+            const assetChecklist: string[] = Array.isArray(parsed?.assetChecklist)
+                ? parsed.assetChecklist.filter((item: unknown): item is string => typeof item === 'string')
+                : [];
+
+            return { beats, assetChecklist };
+        } catch (error) {
+            lastError = error;
+            console.error(`Attempt ${attempt} failed:`, error);
+            if (attempt < MAX_RETRIES) {
+                await sleep(INITIAL_DELAY_MS * Math.pow(2, attempt - 1));
+            }
+        }
+    }
+
+    throw new Error(getFriendlyErrorMessage(lastError));
+};
+
+export const generateShotPrompts = async (
+    beatText: string,
+    styleGuide?: string
+): Promise<ShotPrompt[]> => {
+    if (!ai) {
+        throw new Error("API Key is not configured. Please add your key to the `env.js` file in the project root.");
+    }
+
+    const trimmedBeat = beatText?.trim();
+    if (!trimmedBeat) {
+        throw new Error('Please provide a scene beat to storyboard.');
+    }
+
+    const directive = `You are a cinematographer crafting storyboard prompts for generative imagery. Break the provided beat into cinematic shots ready for image or video generation.
+
+Beat Details:
+"""
+${trimmedBeat}
+"""${styleGuide?.trim() ? `
+
+Style Guide:
+${styleGuide.trim()}` : ''}
+
+For each shot supply: title, description (what happens), framing/composition, lens information, lighting/mood, motion keywords, cameraMovement, and a final outputPrompt string suitable for an image/video model.
+
+Return JSON with a "shots" array of shot objects.`;
+
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        try {
+            const response = await ai.models.generateContent({
+                model: 'gemini-2.5-flash',
+                contents: directive,
+                config: {
+                    responseMimeType: 'application/json',
+                    responseSchema: {
+                        type: Type.OBJECT,
+                        properties: {
+                            shots: {
+                                type: Type.ARRAY,
+                                items: {
+                                    type: Type.OBJECT,
+                                    properties: {
+                                        title: { type: Type.STRING },
+                                        description: { type: Type.STRING },
+                                        framing: { type: Type.STRING },
+                                        lens: { type: Type.STRING },
+                                        lighting: { type: Type.STRING },
+                                        motion: { type: Type.STRING },
+                                        cameraMovement: { type: Type.STRING },
+                                        outputPrompt: { type: Type.STRING },
+                                    },
+                                    required: ['title', 'description', 'framing', 'lens', 'lighting', 'motion', 'cameraMovement', 'outputPrompt'],
+                                },
+                            },
+                        },
+                        required: ['shots'],
+                    },
+                },
+            });
+
+            const text = response.text;
+            if (!text) {
+                throw new Error('The model returned an empty response.');
+            }
+
+            let parsed: any;
+            try {
+                parsed = JSON.parse(text);
+            } catch (parseError) {
+                throw new Error('The model returned an invalid shot prompt format.');
+            }
+
+            const shots: ShotPrompt[] = Array.isArray(parsed?.shots)
+                ? parsed.shots.map((shot: any, index: number): ShotPrompt => ({
+                    id: typeof shot?.id === 'string' && shot.id.trim() ? shot.id : `shot_${index + 1}`,
+                    title: typeof shot?.title === 'string' ? shot.title : `Shot ${index + 1}`,
+                    description: typeof shot?.description === 'string' ? shot.description : '',
+                    framing: typeof shot?.framing === 'string' ? shot.framing : '',
+                    lens: typeof shot?.lens === 'string' ? shot.lens : '',
+                    lighting: typeof shot?.lighting === 'string' ? shot.lighting : '',
+                    motion: typeof shot?.motion === 'string' ? shot.motion : '',
+                    cameraMovement: typeof shot?.cameraMovement === 'string' ? shot.cameraMovement : '',
+                    outputPrompt: typeof shot?.outputPrompt === 'string' ? shot.outputPrompt : '',
+                }))
+                : [];
+
+            return shots;
         } catch (error) {
             lastError = error;
             console.error(`Attempt ${attempt} failed:`, error);
@@ -645,6 +939,53 @@ export const mixImagesWithPrompt = async (
             }
             throw new Error("No image was generated. The model may have refused the prompt.");
 
+        } catch (error) {
+            lastError = error;
+            console.error(`Attempt ${attempt} failed:`, error);
+            if (attempt < MAX_RETRIES) {
+                await sleep(INITIAL_DELAY_MS * Math.pow(2, attempt - 1));
+            }
+        }
+    }
+
+    throw new Error(getFriendlyErrorMessage(lastError));
+};
+
+export const generateVideoKeyframe = async (
+    base64Images: string[],
+    prompt: string
+): Promise<string> => {
+    if (!ai) {
+        throw new Error("API Key is not configured. Please add your key to the `env.js` file in the project root.");
+    }
+
+    if (base64Images.length === 0) {
+        throw new Error('Provide at least one reference image to build a keyframe.');
+    }
+
+    const imageParts = base64Images.map(dataUrlToPart);
+    const directive = `Synthesize a single cinematic keyframe to seed video generation. Blend the references cohesively, maintain character likeness, and ensure dynamic lighting and depth. Prompt: ${prompt}`;
+    const allParts = [...imageParts, { text: directive }];
+
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        try {
+            const response = await ai.models.generateContent({
+                model: 'gemini-2.5-flash-image-preview',
+                contents: { parts: allParts },
+                config: {
+                    responseModalities: [Modality.IMAGE, Modality.TEXT],
+                },
+            });
+
+            for (const part of response.candidates[0].content.parts) {
+                if (part.inlineData) {
+                    const base64ImageBytes: string = part.inlineData.data;
+                    return `data:${part.inlineData.mimeType};base64,${base64ImageBytes}`;
+                }
+            }
+            throw new Error('No keyframe image was generated. The model may have refused the prompt.');
         } catch (error) {
             lastError = error;
             console.error(`Attempt ${attempt} failed:`, error);

--- a/types.ts
+++ b/types.ts
@@ -11,6 +11,11 @@ export enum NodeType {
   StoryExpander = 'STORY_EXPANDER_NODE',
   ShortStoryWriter = 'SHORT_STORY_WRITER_NODE',
   ScreenplayWriter = 'SCREENPLAY_WRITER_NODE',
+  WorldBible = 'WORLD_BIBLE_NODE',
+  SceneBeatPlanner = 'SCENE_BEAT_PLANNER_NODE',
+  ShotStoryboard = 'SHOT_STORYBOARD_NODE',
+  VideoKeyframeInitializer = 'VIDEO_KEYFRAME_INITIALIZER_NODE',
+  VideoSequencePlanner = 'VIDEO_SEQUENCE_PLANNER_NODE',
 }
 
 export enum HandleType {
@@ -30,6 +35,48 @@ export interface Connection {
 export interface StoryCharacter {
   name: string;
   description: string;
+}
+
+export interface WorldBibleSections {
+  worldSummary: string;
+  keyLocations: string;
+  factions: string;
+  visualMotifs: string;
+  continuityRules: string;
+}
+
+export interface SceneBeat {
+  id: string;
+  title: string;
+  summary: string;
+  setting: string;
+  characters: string[];
+  goal: string;
+  conflict: string;
+  visualNotes: string;
+  requiredAssets: string[];
+}
+
+export interface ShotPrompt {
+  id: string;
+  title: string;
+  description: string;
+  framing: string;
+  lens: string;
+  lighting: string;
+  motion: string;
+  cameraMovement: string;
+  outputPrompt: string;
+}
+
+export interface TimelineClipPlan {
+  clipNodeId: string;
+  clipLabel: string;
+  prompt?: string;
+  videoUrl?: string;
+  durationSeconds?: number;
+  transition?: string;
+  notes?: string;
 }
 
 export interface NodeData {
@@ -97,6 +144,38 @@ export interface NodeData {
     // For Screenplay Writer
     pitch?: string;
     screenplayText?: string;
+
+    // For World Bible
+    worldPrompt?: string;
+    worldSummary?: string;
+    keyLocations?: string;
+    factionsAndAllies?: string;
+    visualMotifs?: string;
+    continuityRules?: string;
+
+    // For Scene Beat Planner
+    scenePlannerInput?: string;
+    structurePreset?: string;
+    sceneBeats?: SceneBeat[];
+    sceneBeatsText?: string;
+    assetChecklistText?: string;
+
+    // For Shot Storyboard
+    shotReferenceText?: string;
+    shotStyleGuide?: string;
+    shotPrompts?: ShotPrompt[];
+    shotPromptsText?: string;
+
+    // For Video Keyframe Initializer
+    keyframePrompt?: string;
+    keyframeSourceImageUrls?: string[];
+    keyframeImageUrl?: string;
+
+    // For Video Sequence Planner
+    timelineNotes?: string;
+    musicCue?: string;
+    timelineClips?: TimelineClipPlan[];
+    timelineExportText?: string;
   };
 }
 

--- a/utils/node-spec.ts
+++ b/utils/node-spec.ts
@@ -64,6 +64,45 @@ export const NODE_SPEC: { [key in NodeType]: NodeSpec } = {
       { id: 'screenplay_output', type: HandleType.Text, label: 'Screenplay Text' },
     ],
   },
+  [NodeType.WorldBible]: {
+    inputs: [{ id: 'world_prompt_input', type: HandleType.Text, label: 'World Prompt' }],
+    outputs: [
+      { id: 'world_summary_output', type: HandleType.Text, label: 'World Summary' },
+      { id: 'key_locations_output', type: HandleType.Text, label: 'Key Locations' },
+      { id: 'factions_output', type: HandleType.Text, label: 'Factions & Cast' },
+      { id: 'visual_motifs_output', type: HandleType.Text, label: 'Visual Motifs' },
+      { id: 'continuity_rules_output', type: HandleType.Text, label: 'Continuity Rules' },
+    ],
+  },
+  [NodeType.SceneBeatPlanner]: {
+    inputs: [{ id: 'story_input', type: HandleType.Text, label: 'Story / Premise' }],
+    outputs: [
+      { id: 'scene_beats_output', type: HandleType.Text, label: 'Scene Beats' },
+      { id: 'asset_checklist_output', type: HandleType.Text, label: 'Asset Checklist' },
+    ],
+  },
+  [NodeType.ShotStoryboard]: {
+    inputs: [{ id: 'beat_input', type: HandleType.Text, label: 'Scene Beat' }],
+    outputs: [
+      { id: 'shot_prompts_output', type: HandleType.Text, label: 'Shot Prompts' },
+    ],
+  },
+  [NodeType.VideoKeyframeInitializer]: {
+    inputs: [
+      { id: 'character_ref_input', type: HandleType.Image, label: 'Character Ref' },
+      { id: 'location_ref_input', type: HandleType.Image, label: 'Location Ref' },
+      { id: 'continuity_ref_input', type: HandleType.Image, label: 'Continuity Frame' },
+      { id: 'prompt_input', type: HandleType.Text, label: 'Keyframe Prompt' },
+    ],
+    outputs: [{ id: 'keyframe_image_output', type: HandleType.Image, label: 'Keyframe' }],
+  },
+  [NodeType.VideoSequencePlanner]: {
+    inputs: [
+      { id: 'clip_input', type: HandleType.Video, label: 'Video Clips' },
+      { id: 'notes_input', type: HandleType.Text, label: 'Notes (Optional)' },
+    ],
+    outputs: [{ id: 'timeline_output', type: HandleType.Text, label: 'Timeline Plan' }],
+  },
   [NodeType.VideoGenerator]: {
     inputs: [
       { id: 'image_input', type: HandleType.Image, label: 'Input Image (Optional)' },

--- a/utils/nodeMenuConfig.tsx
+++ b/utils/nodeMenuConfig.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FileText, ScrollText, Edit3, Users as UsersIcon, PenTool, ImagePlus, Wand2, Layers, Clapperboard, UserCog } from 'lucide-react';
+import { FileText, ScrollText, Edit3, Users as UsersIcon, PenTool, ImagePlus, Wand2, Layers, Clapperboard, UserCog, BookOpen, ListChecks, LayoutPanelTop, Sparkles, Film } from 'lucide-react';
 
 export interface NodeMenuCallbacks {
   onAddTextNode: () => void;
@@ -11,9 +11,14 @@ export interface NodeMenuCallbacks {
   onAddStoryExpanderNode: () => void;
   onAddShortStoryWriterNode: () => void;
   onAddScreenplayWriterNode: () => void;
+  onAddWorldBibleNode: () => void;
+  onAddSceneBeatPlannerNode: () => void;
+  onAddShotStoryboardNode: () => void;
   onAddImageEditorNode: () => void;
   onAddImageMixerNode: () => void;
   onAddVideoGeneratorNode: () => void;
+  onAddVideoKeyframeInitializerNode: () => void;
+  onAddVideoSequencePlannerNode: () => void;
 }
 
 export interface NodeMenuItem {
@@ -30,6 +35,9 @@ export interface NodeMenuCategory {
 export const buildStoryToolsCategory = (callbacks: NodeMenuCallbacks): NodeMenuCategory => ({
   title: 'Story Tools',
   items: [
+    { label: 'World Bible', icon: <BookOpen className="w-5 h-5 text-sky-300" />, action: callbacks.onAddWorldBibleNode },
+    { label: 'Scene Beat Planner', icon: <ListChecks className="w-5 h-5 text-emerald-300" />, action: callbacks.onAddSceneBeatPlannerNode },
+    { label: 'Shot Storyboard', icon: <LayoutPanelTop className="w-5 h-5 text-pink-300" />, action: callbacks.onAddShotStoryboardNode },
     { label: 'Screenplay Writer', icon: <Clapperboard className="w-5 h-5 text-purple-400" />, action: callbacks.onAddScreenplayWriterNode },
     { label: 'Short Story Writer', icon: <PenTool className="w-5 h-5 text-yellow-300" />, action: callbacks.onAddShortStoryWriterNode },
     { label: 'Story Expander', icon: <ScrollText className="w-5 h-5 text-purple-400" />, action: callbacks.onAddStoryExpanderNode },
@@ -53,12 +61,14 @@ export const buildNodeMenuCategories = (callbacks: NodeMenuCallbacks): NodeMenuC
       { label: 'Image Generator', icon: <Wand2 className="w-5 h-5 text-blue-400" />, action: callbacks.onAddImageGeneratorNode },
       { label: 'Image Editor', icon: <Edit3 className="w-5 h-5 text-purple-400" />, action: callbacks.onAddImageEditorNode },
       { label: 'Image Mixer', icon: <Layers className="w-5 h-5 text-pink-400" />, action: callbacks.onAddImageMixerNode },
+      { label: 'Video Keyframe Init', icon: <Sparkles className="w-5 h-5 text-amber-300" />, action: callbacks.onAddVideoKeyframeInitializerNode },
     ],
   },
   {
     title: 'Video Tools',
     items: [
       { label: 'Video Generator', icon: <Clapperboard className="w-5 h-5 text-green-400" />, action: callbacks.onAddVideoGeneratorNode },
+      { label: 'Video Sequence Planner', icon: <Film className="w-5 h-5 text-indigo-300" />, action: callbacks.onAddVideoSequencePlannerNode },
     ],
   },
 ];
@@ -79,12 +89,14 @@ export const buildAllNodeMenuCategories = (callbacks: NodeMenuCallbacks): NodeMe
       { label: 'Image Generator', icon: <Wand2 className="w-5 h-5 text-blue-400" />, action: callbacks.onAddImageGeneratorNode },
       { label: 'Image Editor', icon: <Edit3 className="w-5 h-5 text-purple-400" />, action: callbacks.onAddImageEditorNode },
       { label: 'Image Mixer', icon: <Layers className="w-5 h-5 text-pink-400" />, action: callbacks.onAddImageMixerNode },
+      { label: 'Video Keyframe Init', icon: <Sparkles className="w-5 h-5 text-amber-300" />, action: callbacks.onAddVideoKeyframeInitializerNode },
     ],
   },
   {
     title: 'Video Tools',
     items: [
       { label: 'Video Generator', icon: <Clapperboard className="w-5 h-5 text-green-400" />, action: callbacks.onAddVideoGeneratorNode },
+      { label: 'Video Sequence Planner', icon: <Film className="w-5 h-5 text-indigo-300" />, action: callbacks.onAddVideoSequencePlannerNode },
     ],
   },
 ];


### PR DESCRIPTION
## Summary
- add world bible, scene beat planner, shot storyboard, video keyframe initializer, and video sequence planner nodes to the canvas
- wire new handlers through the toolbar, canvas, and application state while extending Gemini service support for each node
- adjust the entry HTML script loading so Vite can bundle env.js during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd923d9958832ea94aec6c48ed81ba