### PR TITLE
Add Veo 3.1 controls to video generator

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -99,7 +99,10 @@ const createDefaultDataForType = (type: NodeType): NodeData['data'] => {
     case NodeType.VideoGenerator:
       return {
         editDescription: 'A majestic eagle soaring over mountains',
-        videoModel: 'veo-3.0-fast-generate-001',
+        videoModel: 'veo-3.1-fast-generate-preview',
+        videoResolution: '720p',
+        videoDuration: '6',
+        videoAspectRatio: '16:9',
       } as NodeData['data'];
     case NodeType.TextGenerator:
       return { prompt: 'Write a short story about a robot who discovers music.' } as NodeData['data'];
@@ -2256,7 +2259,7 @@ const AppContent: React.FC = () => {
     const sourceNode = nodes.find(n => n.id === nodeId);
     if (!sourceNode || sourceNode.type !== NodeType.VideoGenerator) return;
   
-    const { inputImageUrl, editDescription, videoModel } = sourceNode.data;
+    const { inputImageUrl, editDescription, videoModel, videoResolution, videoDuration, videoAspectRatio } = sourceNode.data;
     
     if (!editDescription) {
         updateNodeData(nodeId, { error: 'Please provide a video prompt.' });
@@ -2277,7 +2280,21 @@ const AppContent: React.FC = () => {
         const onProgress = (message: string) => {
             updateNodeData(nodeId, { generationProgressMessage: message });
         };
-        const videoUrl = await generateVideoFromPrompt(editDescription, inputImageUrl, videoModel || 'veo-2.0-generate-001', onProgress);
+        const resolution = videoResolution || '720p';
+        const aspectRatio = videoAspectRatio || '16:9';
+        const duration = resolution === '1080p' ? '8' : (videoDuration || '6');
+
+        const videoUrl = await generateVideoFromPrompt(
+            editDescription,
+            inputImageUrl,
+            videoModel || 'veo-3.1-fast-generate-preview',
+            {
+                resolution,
+                aspectRatio,
+                duration,
+            },
+            onProgress
+        );
         const elapsed = Date.now() - startTime;
         updateNodeData(nodeId, {
             videoUrl,

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A visual node-based editor for creating powerful AI workflows using the Gemini A
 - **Image Generator** - Create images from text prompts with aspect ratio control
 - **Image Editor** - Edit images using natural language prompts
 - **Image Mixer** - Blend multiple images with AI-powered mixing
-- **Video Generator** - Generate videos from text descriptions
+- **Video Generator** - Generate videos from text or image prompts with Veo 3.1 resolution, aspect ratio, and duration controls
 
 ### Workflow Features
 - **Visual Node Canvas** - Intuitive drag-and-drop interface for connecting AI operations

--- a/components/Node.tsx
+++ b/components/Node.tsx
@@ -1654,8 +1654,15 @@ const Node: React.FC<NodeProps> = ({
           )
       })()}
 
-      {node.type === NodeType.VideoGenerator && (
-        <>
+      {node.type === NodeType.VideoGenerator && (() => {
+        const resolution = node.data.videoResolution || '720p';
+        const durationOptions = resolution === '1080p' ? ['8'] : ['4', '6', '8'];
+        const durationValue = resolution === '1080p' ? '8' : (node.data.videoDuration || '6');
+        const aspectRatio = node.data.videoAspectRatio || '16:9';
+        const modelValue = node.data.videoModel || 'veo-3.1-fast-generate-preview';
+
+        return (
+          <>
             <NodeHeader
                 title='Video Generator'
                 icon={<Clapperboard className="w-4 h-4 text-green-400" />}
@@ -1676,10 +1683,73 @@ const Node: React.FC<NodeProps> = ({
                 </div>
                 <div>
                     <label htmlFor={`video-model-${node.id}`} className={labelClassName}>Video Model</label>
-                    <select id={`video-model-${node.id}`} className={selectClassName} value={node.data.videoModel || 'veo-3.0-fast-generate-001'} onChange={(e) => onUpdateData(node.id, { videoModel: e.target.value })} onMouseDown={(e) => e.stopPropagation()} >
+                    <select
+                        id={`video-model-${node.id}`}
+                        className={selectClassName}
+                        value={modelValue}
+                        onChange={(e) => onUpdateData(node.id, { videoModel: e.target.value })}
+                        onMouseDown={(e) => e.stopPropagation()}
+                    >
+                        <option value="veo-3.1-fast-generate-preview">Veo 3.1 (Fast Preview)</option>
                         <option value="veo-3.0-fast-generate-001">Veo 3.0 (Fast)</option>
                         <option value="veo-2.0-generate-001">Veo 2.0</option>
                     </select>
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    <div>
+                        <label htmlFor={`video-resolution-${node.id}`} className={labelClassName}>Resolution</label>
+                        <select
+                            id={`video-resolution-${node.id}`}
+                            className={selectClassName}
+                            value={resolution}
+                            onChange={(e) => {
+                                const newResolution = e.target.value as '720p' | '1080p';
+                                const updates: Partial<NodeData['data']> = { videoResolution: newResolution };
+                                if (newResolution === '1080p') {
+                                    updates.videoDuration = '8';
+                                } else if (resolution === '1080p' && node.data.videoDuration === '8') {
+                                    updates.videoDuration = '6';
+                                }
+                                onUpdateData(node.id, updates);
+                            }}
+                            onMouseDown={(e) => e.stopPropagation()}
+                        >
+                            <option value="720p">720p</option>
+                            <option value="1080p">1080p</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label htmlFor={`video-aspect-${node.id}`} className={labelClassName}>Aspect Ratio</label>
+                        <select
+                            id={`video-aspect-${node.id}`}
+                            className={selectClassName}
+                            value={aspectRatio}
+                            onChange={(e) => onUpdateData(node.id, { videoAspectRatio: e.target.value })}
+                            onMouseDown={(e) => e.stopPropagation()}
+                        >
+                            <option value="16:9">16:9 (Landscape)</option>
+                            <option value="9:16">9:16 (Vertical)</option>
+                            <option value="1:1">1:1 (Square)</option>
+                        </select>
+                    </div>
+                </div>
+                <div>
+                    <label htmlFor={`video-duration-${node.id}`} className={labelClassName}>Duration (seconds)</label>
+                    <select
+                        id={`video-duration-${node.id}`}
+                        className={selectClassName}
+                        value={durationValue}
+                        onChange={(e) => onUpdateData(node.id, { videoDuration: e.target.value })}
+                        onMouseDown={(e) => e.stopPropagation()}
+                        disabled={resolution === '1080p'}
+                    >
+                        {durationOptions.map(option => (
+                            <option key={option} value={option}>{option}</option>
+                        ))}
+                    </select>
+                    {resolution === '1080p' && (
+                        <p className="text-[10px] text-gray-400 mt-1">1080p clips are limited to 8 seconds.</p>
+                    )}
                 </div>
                 <div ref={el => handleAnchorRefs.current['prompt_input'] = el}>
                     <label htmlFor={`video-desc-${node.id}`} className={labelClassName}>Video Prompt</label>
@@ -1717,8 +1787,9 @@ const Node: React.FC<NodeProps> = ({
                 : previewImage ? <img key={previewImage} ref={minimizedImageRef} src={previewImage} alt="Preview" className="w-full h-full object-contain" />
                 : <Video className={`w-8 h-8 ${styles.node.imagePlaceholderIcon}`} />}
             </div> )}
-        </>
-      )}
+          </>
+        );
+      })()}
       {contextMenuPosition && (
         <NodeContextMenu
           position={contextMenuPosition}

--- a/types.ts
+++ b/types.ts
@@ -71,6 +71,9 @@ export interface NodeData {
     
     // For Video Generator
     videoModel?: string;
+    videoResolution?: '720p' | '1080p';
+    videoDuration?: '4' | '6' | '8';
+    videoAspectRatio?: '16:9' | '9:16' | '1:1';
     videoUrl?: string;
     generationProgressMessage?: string;
     generationStartTimeMs?: number;

--- a/utils/templates.ts
+++ b/utils/templates.ts
@@ -110,7 +110,10 @@ export const templates: { [key: string]: Template } = {
                 type: NodeType.VideoGenerator,
                 position: { x: 400, y: 240 },
                 data: {
-                    videoModel: 'veo-3.0-fast-generate-001',
+                    videoModel: 'veo-3.1-fast-generate-preview',
+                    videoResolution: '720p',
+                    videoDuration: '6',
+                    videoAspectRatio: '16:9',
                     editDescription: 'A sweeping camera move through neon rain as the crew escapes across suspended railways.',
                 },
             },


### PR DESCRIPTION
## Summary
- add Veo 3.1 fast preview as the default video model and expose resolution, aspect ratio, and duration controls in the node UI
- instantiate a fresh GoogleGenAI client for each request and forward the new video configuration parameters to the Gemini API
- update templates and documentation to reflect the new Veo 3.1 capabilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f8dd2e5908832e84f7281e277c8fc2